### PR TITLE
Removed duplicate include of protoCap.cpp in Makefile.common.  This c…

### DIFF
--- a/makefiles/Makefile.common
+++ b/makefiles/Makefile.common
@@ -43,7 +43,7 @@ KIT_SRC = $(COMMON)/protoAddress.cpp  $(COMMON)/protoApp.cpp $(COMMON)/protoBase
           $(COMMON)/protoRouteMgr.cpp $(COMMON)/protoRouteTable.cpp \
           $(COMMON)/protoTime.cpp $(COMMON)/protoTimer.cpp \
           $(COMMON)/protoTree.cpp $(COMMON)/protoList.cpp $(COMMON)/protoQueue.cpp \
-          $(COMMON)/protoVif.cpp $(COMMON)/protoCap.cpp  \
+          $(COMMON)/protoVif.cpp  \
           $(COMMON)/protoSerial.cpp $(COMMON)/protoLFSR.cpp \
           $(COMMON)/protoNet.cpp $(COMMON)/protoFile.cpp $(COMMON)/protoString.cpp \
           $(SYSTEM_SRC)


### PR DESCRIPTION
…aused a build of libprotokit.so to fail on Linux.
You should now be able to run `make -f Makefile.linux libprotokit.so`.