### PR TITLE
CMake: Fix examples build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,7 +281,8 @@ if(BUILD_EXAMPLES)
 
 	foreach(example ${examples})
 		add_executable(${example} examples/${example}.cpp)
-		target_link_libraries(${example} PRIVATE protolib)
+		target_link_libraries(${example} PRIVATE protokit)
+		include_directories(${CMAKE_SOURCE_DIR}/include)
 	endforeach()
 endif()
 


### PR DESCRIPTION
* Examples could't find headers. Add the source code's include directory to the example builds
* Examples needed to be updated to link protokit lib instead of protolib to sync with lib change name in 2772a18