### PR TITLE
Updates include install directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,7 @@ install( EXPORT protokitTargets
 	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/protokit
 )
 
-install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/protokit)
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 if(BUILD_EXAMPLES)
 	# Setup examples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,12 +244,14 @@ install( TARGETS protokit EXPORT protokitTargets
         INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} )
 
 install( EXPORT protokitTargets
-	FILE protokitTargets.cmake
+	FILE protokitConfig.cmake
 	NAMESPACE protokit::
 	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/protokit
 )
 
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+export(PACKAGE protokit)
 
 if(BUILD_EXAMPLES)
 	# Setup examples


### PR DESCRIPTION
The includes should match, i.e. if there is no /include/protokit you should not install to /include/protokit. This is confusing (for humans and build systems).