### PR TITLE
Forces static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,7 @@ endif()
 include(GNUInstallDirs)
 
 # Setup target
-add_library(protokit ${PLATFORM_SOURCE_FILES} ${COMMON_SOURCE_FILES} ${PUBLIC_HEADER_FILES})
+add_library(protokit STATIC ${PLATFORM_SOURCE_FILES} ${COMMON_SOURCE_FILES} ${PUBLIC_HEADER_FILES})
 add_library(protokit::protokit ALIAS protokit)
 target_link_libraries(protokit PRIVATE ${PLATFORM_LIBS})
 target_compile_definitions(protokit PUBLIC ${PLATFORM_DEFINITIONS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,11 @@ endif()
 include(GNUInstallDirs)
 
 # Setup target
-add_library(protokit STATIC ${PLATFORM_SOURCE_FILES} ${COMMON_SOURCE_FILES} ${PUBLIC_HEADER_FILES})
+if(MSVC)
+	SET(PROTOKIT_LIBRARY_TYPE STATIC)
+endif()
+
+add_library(protokit ${PROTOKIT_LIBRARY_TYPE} ${PLATFORM_SOURCE_FILES} ${COMMON_SOURCE_FILES} ${PUBLIC_HEADER_FILES})
 add_library(protokit::protokit ALIAS protokit)
 target_link_libraries(protokit PRIVATE ${PLATFORM_LIBS})
 target_compile_definitions(protokit PUBLIC ${PLATFORM_DEFINITIONS})


### PR DESCRIPTION
Building protolib as a shared lib does not make sense (and is not supported with MSVC). This way any global options such as BUILD_SHARED_LIBS are ignored. If there is a use case for shared builds I can add an option. But tbh I think the use case of protolib warrants a static lib as it is more of a toolbox.