### PR TITLE
do Windows timing via std::chrono

### DIFF
--- a/include/protoDefs.h
+++ b/include/protoDefs.h
@@ -78,7 +78,19 @@ inline void ProtoSystemTime(struct timeval& theTime)
 
 #else  // !SIMULATE
 
-#ifdef WIN32
+#if defined(WIN32) && ((__cplusplus >= 201103L) || (_MSC_VER >= 1900))
+
+#include <chrono>
+inline void ProtoSystemTime(struct timeval& theTime)
+{
+    std::chrono::microseconds epochTime = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::system_clock::now().time_since_epoch()
+        );
+    theTime.tv_sec = (long)(epochTime.count() / 1000000);
+    theTime.tv_usec = (long)(epochTime.count() % 1000000);
+}
+
+#elif defined(WIN32)
 
 // NOTE: On _some_ WIN32 systems, it _may_ be beneficial to enable
 //       the "USE_PERFORMANCE_COUNTER" macro.  It is done for WinCE


### PR DESCRIPTION
The current Windows implementation using QueryPerformanceCounter is very unstable and jumps back and forth by 0.5 seconds on my Windows 10 machine.
This caused very weird lags while using NORM, which uses Protolib for timing.

Since C++ 11 we can use *std::chrono* for timing, which is easier to use than *QueryPerformanceCounter* while also providing sub-second granularity.

Currently, *std::chrono* is only used on Windows.
Maybe we should also use this on Linux systems instead of *gettimeofday*? This would reduce the platform-dependent code.