### PR TITLE
Fixed Segmentation Fault errors when importing protokit

### DIFF
--- a/src/python/protokit.cpp
+++ b/src/python/protokit.cpp
@@ -29,10 +29,17 @@ static PyMethodDef protokit_methods[] = {{NULL}};
     };
 #endif  // end PY_MAJOR_VERSION >= 3
 
+// #ifndef PyMODINIT_FUNC   //declarations for DLL import/export 
+// #define PyMODINIT_FUNC void
+// #endif
+
 static PyObject *
 moduleinit(void)
 {
     PyObject *m;
+
+    if (PyType_Ready(&PipeType) < 0)
+            return m;
 
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&moduledef);

--- a/src/python/protokit.cpp
+++ b/src/python/protokit.cpp
@@ -29,9 +29,6 @@ static PyMethodDef protokit_methods[] = {{NULL}};
     };
 #endif  // end PY_MAJOR_VERSION >= 3
 
-// #ifndef PyMODINIT_FUNC   //declarations for DLL import/export 
-// #define PyMODINIT_FUNC void
-// #endif
 
 static PyObject *
 moduleinit(void)


### PR DESCRIPTION
Issue with Python2 and Python3 init functions having different types. Resolved.