### PR TITLE
fix compiling with MSVC

### DIFF
--- a/src/common/protoSocket.cpp
+++ b/src/common/protoSocket.cpp
@@ -2817,12 +2817,12 @@ bool ProtoSocket::SetFlowLabel(UINT32 label)
     if (label && !flow_label)
     {
        int on = 1;
-       result = setsockopt(handle, SOL_IPV6, IPV6_FLOWINFO_SEND, (void*)&on, sizeof(on));
+       result = setsockopt(handle, SOL_IPV6, IPV6_FLOWINFO_SEND, (char*)&on, sizeof(on));
     }
     else if (!label && flow_label)
     {
         int off = 0;
-        result = setsockopt(handle, SOL_IPV6, IPV6_FLOWINFO_SEND, (void*)&off, sizeof(off));
+        result = setsockopt(handle, SOL_IPV6, IPV6_FLOWINFO_SEND, (char*)&off, sizeof(off));
     }
 #endif  // SOL_IPV6
     if (0 == result)


### PR DESCRIPTION
On Windows with MS VC 2017, the function signature for `setsockopt` is:

```c
int setsockopt(SOCKET,int,int,const char *,int)':
```

This PR fixes a two typecasts that currently cause the MSVC build to fail.
In all other places in the same file, the data for setsockopt is cast to `char*` anyway.